### PR TITLE
Updates for latest (1.7.2) flocker compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ClusterHQ/Flocker provides an efficient and easy way to connect persistent store
 ##Installation
 Make sure that flocker node service has been installed
 (https://docs.clusterhq.com/en/1.2.0/install/install-node.html)
-python setup.py install
+/opt/flocker/bin/python2.7 setup.py install
 
 ##Testing
 Create a configuration file: /etc/flocker/nedge.yml.

--- a/nedge_flocker_plugin/nedge_objstor.py
+++ b/nedge_flocker_plugin/nedge_objstor.py
@@ -4,8 +4,7 @@
 from flocker.node.agents.blockdevice import (
     VolumeException, AlreadyAttachedVolume,
     UnknownVolume, UnattachedVolume,
-    IBlockDeviceAPI, _blockdevicevolume_from_dataset_id,
-    _blockdevicevolume_from_blockdevice_id
+    IBlockDeviceAPI, BlockDeviceVolume
 )
 
 from eliot import Message, Logger
@@ -71,8 +70,9 @@ class NedgeBlockDeviceAPI(object):
         return self._chunk_sz
 
     def create_volume(self, dataset_id, size):
-        volume = _blockdevicevolume_from_dataset_id(size=size,
-                                                    dataset_id=dataset_id)
+        volume = BlockDeviceVolume(size=size, attached_to=None,
+                                 dataset_id=dataset_id,
+                                 blockdevice_id=u"nedge-{0}".format(dataset_id))
         obj_idx = len(self._objs_list)
         self._reqdata.clear();
         self._reqdata['number'] = obj_idx

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with codecs.open('DESCRIPTION.rst', encoding='utf-8') as f:
 
 setup(
     name='nedge_flocker_plugin',
-    version='1.0',
+    version='1.1',
     description='NexentaEdge Backend Plugin for ClusterHQ/Flocker',
     long_description=long_description,
     author='Nabin Acharya',


### PR DESCRIPTION
1. Improved setup instructions
2. Bumped up version to 1.1
3. Removed now unsupported helper function _blockdevicevolume_from_dataset_id()
